### PR TITLE
Restore compatibility with GNOME 3.28

### DIFF
--- a/src/interface.js
+++ b/src/interface.js
@@ -18,11 +18,11 @@
 
 const Gio = imports.gi.Gio;
 
-const BUS_NAME = 'net.connman';
-const VPN_BUS_NAME = 'net.connman.vpn';
-const MANAGER_PATH = '/';
-const AGENT_PATH = '/net/connman/gnome3/agent';
-const VPN_AGENT_PATH = '/net/connman/gnome3/vpn/agent';
+var BUS_NAME = 'net.connman';
+var VPN_BUS_NAME = 'net.connman.vpn';
+var MANAGER_PATH = '/';
+var AGENT_PATH = '/net/connman/gnome3/agent';
+var VPN_AGENT_PATH = '/net/connman/gnome3/vpn/agent';
 
 const _MANAGER_INTERFACE = '<node>\
 <interface name="net.connman.Manager">\


### PR DESCRIPTION
Fixes various breaking and cosmetic problems:

- JS: Replace obsolete "for each" syntax (WIP, this can be made nicer)
- Rework all Lang.Class classes to real classes and register with GObject where needed: https://gitlab.gnome.org/GNOME/gnome-shell/blob/master/HACKING.md#classes
- Rework _init / constructors as needed
- UI: Fix instances of .add() with metadata, replaced with .add_child()
- Fix layout of "Select wireless network" dialog header (remove Icon and use MessageDialogContent)
- Remove overlong string in authentication dialog
- Replace Entry with PasswordEntry in authentication dialog

I could not test VPN functionality because it wouldn't show up in connman at all. 